### PR TITLE
Incoming command queue

### DIFF
--- a/src/whr930.py
+++ b/src/whr930.py
@@ -812,9 +812,11 @@ def handle_commands():
         if message.topic == "house/2/attic/wtw/set_ventilation_level":
             fan_level = int(float(message.payload))
             set_ventilation_level(fan_level)
+            get_ventilation_status()
         elif message.topic == "house/2/attic/wtw/set_comfort_temperature":
             temperature = float(message.payload)
             set_comfort_temperature(temperature)
+            get_temp()
         else:
             info_msg(
                 "Received a message on topic {} where we do not have a handler for at the moment".format(

--- a/src/whr930.py
+++ b/src/whr930.py
@@ -900,18 +900,15 @@ def main():
 
     mqttc.loop_start()
 
+    functions = [get_temp, get_ventilation_status, get_filter_status, get_fan_status, get_bypass_control, get_valve_status, get_status, get_operating_hours, get_preheating_status]
+
     while True:
         try:
-            get_temp()
-            get_ventilation_status()
-            get_filter_status()
-            get_fan_status()
-            get_bypass_control()
-            get_valve_status()
-            get_status()
-            get_operating_hours()
-            get_preheating_status()
-            handle_commands()
+            for func in functions:
+                if len(pending_commands) == 0:
+                    func()
+                else:
+                    handle_commands()
 
             time.sleep(5)
             pass


### PR DESCRIPTION
As the paho mqtt library subscibes to MQTT with a dedicated thread, it's possible we can get some unwanted concurrency issues if a command is received while handling a different method. This PR synchronizes calls to the serial interface by storing command messages and handling them as soon as the previous command is finished.